### PR TITLE
Use relative paths for submodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "include/bonsai_stdlib"]
 	path = include/bonsai_stdlib
-	url = git@github.com:scallyw4g/bonsai_stdlib
+	url = ../bonsai_stdlib.git
 [submodule "scripts"]
 	path = scripts
-	url = git@github.com:scallyw4g/bonsai_build_scripts
+	url = ../bonsai_build_scripts.git
 [submodule "include/bonsai_debug"]
 	path = include/bonsai_debug
-	url = git@github.com:scallyw4g/bonsai_debug
+	url = ../bonsai_debug.git


### PR DESCRIPTION
This allows one to use forked repositories of submodules rather than the previously hardcoded upstream repository.